### PR TITLE
feat: expose custom_filters and additional search parameters

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "pearch",
+  "owner": {
+    "name": "Dmitry Kushnikov",
+    "email": "dkushnikov@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "pearch",
+      "description": "MCP tools (search_people, search_company_leads) + /source skill for structured executive candidate sourcing.",
+      "source": "./plugins/pearch",
+      "category": "productivity",
+      "homepage": "https://github.com/dkushnikov/mcp_pearch"
+    }
+  ]
+}

--- a/pearch_mcp.py
+++ b/pearch_mcp.py
@@ -58,6 +58,13 @@ def search_people(
     reveal_phones: bool = False,
     thread_id: str | None = None,
     offset: int = 0,
+    custom_filters: dict[str, Any] | None = None,
+    custom_filters_mode: str | None = None,
+    strict_filters: bool | None = None,
+    docid_blacklist: list[str] | None = None,
+    high_freshness: bool = False,
+    filter_out_no_emails: bool = False,
+    filter_out_no_phones: bool = False,
     api_key: str | None = None,
     base_url: str | None = None,
 ) -> dict[str, Any]:
@@ -65,7 +72,25 @@ def search_people(
 
     Pass a natural-language query (e.g. "software engineers in California with 5+ years Python").
     search_type: "fast" (1 credit/candidate) or "pro" (5 credits/candidate, higher quality).
-    Optionally pass thread_id from a previous response for follow-up. Returns thread_id, search_results, credits_remaining, total_estimate, status.
+    Optionally pass thread_id from a previous response for follow-up.
+
+    custom_filters: structured filters applied on top of the NL query. Searches across ALL experience, not just current role. Example:
+      {"companies": ["Mollie", "Adyen"], "locations": ["Netherlands"], "min_total_experience_years": 5}
+    Available filter fields:
+      - Array (include): locations, languages, titles, industries, companies, universities, keywords, degrees, specialization_categories
+      - Array (exclude): not_locations, not_languages, not_titles, not_current_titles, not_industries, not_companies, not_current_experience_companies, not_universities
+      - Current-only: current_titles, current_experience_companies
+      - Numeric: min/max_linkedin_followers, min/max_total_experience_years, min/max_estimated_age, min/max_current_experience_years
+      - Boolean: studied_at_top_universities, has_startup_experience, has_saas_experience, has_b2b_experience, has_b2c_experience
+      - Exact: first_name, middle_name, last_name, gender ("male"/"female")
+    custom_filters_mode: "exact" (only use passed filters) or "smart" (merge with LLM-generated filters from query). Default: smart.
+    strict_filters: enforce exact title matching.
+    docid_blacklist: list of profile IDs to exclude from results.
+    high_freshness: real-time profile updates (+2 credits/candidate).
+    filter_out_no_emails: only return profiles with email addresses (+1 credit/candidate).
+    filter_out_no_phones: only return profiles with phone numbers (+1 credit/candidate).
+
+    Returns thread_id, search_results, credits_remaining, total_estimate, status.
     """
     body: dict[str, Any] = {
         "query": query,
@@ -79,6 +104,20 @@ def search_people(
     }
     if thread_id:
         body["thread_id"] = thread_id
+    if custom_filters:
+        body["custom_filters"] = custom_filters
+    if custom_filters_mode:
+        body["custom_filters_mode"] = custom_filters_mode
+    if strict_filters is not None:
+        body["strict_filters"] = strict_filters
+    if docid_blacklist:
+        body["docid_blacklist"] = docid_blacklist
+    if high_freshness:
+        body["high_freshness"] = high_freshness
+    if filter_out_no_emails:
+        body["filter_out_no_emails"] = filter_out_no_emails
+    if filter_out_no_phones:
+        body["filter_out_no_phones"] = filter_out_no_phones
     return _request("v2/search", body, api_key=api_key, base_url=base_url)
 
 
@@ -90,6 +129,10 @@ def search_company_leads(
     leads_limit: int = 3,
     reveal_emails: bool = False,
     reveal_phones: bool = False,
+    filter_out_no_emails: bool = False,
+    filter_out_no_phones: bool = False,
+    high_freshness: bool = False,
+    select_top_leads: bool = True,
     outreach_message_instruction: str | None = None,
     thread_id: str | None = None,
     api_key: str | None = None,
@@ -100,6 +143,10 @@ def search_company_leads(
     company_query: natural-language description of companies (e.g. "AI startups in San Francisco with 50-200 employees").
     lead_query: optional, who to find at those companies (e.g. "CTOs and engineering managers"). Do not put company criteria here.
     limit: max companies to return. leads_limit: leads per company.
+    filter_out_no_emails: only return leads with email addresses.
+    filter_out_no_phones: only return leads with phone numbers.
+    high_freshness: real-time profile updates for leads.
+    select_top_leads: AI-select best matching leads per company (default: true).
     Optionally pass outreach_message_instruction to generate personalized outreach text per lead.
     Returns thread_id, search_results (companies with leads), query, duration.
     """
@@ -116,6 +163,14 @@ def search_company_leads(
         body["outreach_message_instruction"] = outreach_message_instruction
     if thread_id:
         body["thread_id"] = thread_id
+    if filter_out_no_emails:
+        body["filter_out_no_emails"] = filter_out_no_emails
+    if filter_out_no_phones:
+        body["filter_out_no_phones"] = filter_out_no_phones
+    if high_freshness:
+        body["high_freshness"] = high_freshness
+    if not select_top_leads:
+        body["select_top_leads"] = select_top_leads
     return _request("v2/search_company_leads", body, api_key=api_key, base_url=base_url)
 
 

--- a/plugins/pearch/.mcp.json
+++ b/plugins/pearch/.mcp.json
@@ -1,7 +1,7 @@
 {
   "pearch": {
     "command": "uv",
-    "args": ["run", "--with", "fastmcp", "fastmcp", "run", "${CLAUDE_PLUGIN_ROOT}/../../pearch_mcp.py"],
+    "args": ["run", "--with", "fastmcp", "fastmcp", "run", "/Users/dkushnikov/Code/mcp_pearch/pearch_mcp.py"],
     "env": {
       "PEARCH_API_KEY": "${PEARCH_API_KEY}"
     }

--- a/plugins/pearch/.mcp.json
+++ b/plugins/pearch/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "pearch": {
+    "command": "uv",
+    "args": ["run", "--with", "fastmcp", "fastmcp", "run", "${CLAUDE_PLUGIN_ROOT}/../../pearch_mcp.py"],
+    "env": {
+      "PEARCH_API_KEY": "${PEARCH_API_KEY}"
+    }
+  }
+}

--- a/plugins/pearch/plugin.json
+++ b/plugins/pearch/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "pearch",
+  "version": "0.1.0",
+  "description": "Candidate sourcing via Pearch.ai: natural-language people search, company leads, and structured exec sourcing workflows.",
+  "author": {
+    "name": "Dmitry Kushnikov"
+  },
+  "repository": "https://github.com/dkushnikov/mcp_pearch",
+  "license": "MIT",
+  "keywords": [
+    "pearch",
+    "sourcing",
+    "recruiting",
+    "candidates",
+    "people-search",
+    "exec-search"
+  ]
+}

--- a/plugins/pearch/skills/source/SKILL.md
+++ b/plugins/pearch/skills/source/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: source
+description: "Executive candidate sourcing via Pearch.ai. Trigger with 'source candidates', 'найди кандидатов', 'source for [position]', 'поиск кандидатов', 'exec search', 'talent search', or when the user asks to find people for a hiring position. Runs a multi-query search pipeline, evaluates candidates against hiring criteria, and produces a ranked shortlist."
+---
+
+# /source — Executive Candidate Sourcing
+
+Multi-query sourcing pipeline using Pearch.ai MCP tools. Finds candidates that single queries miss by combining title-based, experience-based, and alumni-based search strategies.
+
+## Usage
+
+```
+/source Head of People Experience
+/source [position name or description]
+/source              ← will ask which position
+```
+
+## Pipeline
+
+### Step 0: Preparation
+
+1. **Identify position.** If the user names a position, look for the matching file in `Hiring/` directory of the current vault (or Manychat vault). Read the position file for context: scope, team size, must-haves, anti-patterns.
+2. **Read evaluation criteria.** Read `Hiring/hiring-criteria.md` for the 7-dim scoring rubric and company values.
+3. **Title expansion.** From the position title, generate 10-15 title variations that companies use for the same role. Include Director/Head/VP variants, L&D/Development/Experience/Culture/Talent/Programs synonyms. This compensates for naming variance across companies.
+4. **Identify target companies.** Based on position domain, generate a list of 5-10 companies where ideal candidates might work or have worked. Consider: direct competitors, adjacent companies, same-stage B2B SaaS, same-function leaders. These will be used in custom_filters.
+
+### Step 1: Type A — Title + Company Type (current-state search)
+
+Search for candidates who currently hold a matching title at a matching company type.
+
+```
+search_people(
+  query="[expanded titles] at [company type] with [key requirements]. Based in [location].",
+  limit=20,
+  insights=true,
+  profile_scoring=true
+)
+```
+
+This catches **obvious matches** — people currently in the right role at the right type of company.
+
+### Step 2: Type A+ — Title + custom_filters.companies (full-history search)
+
+Search for candidates with matching titles who have **ever worked** at target companies. This is the critical query that finds people who left tech for non-tech companies but have the right experience.
+
+```
+search_people(
+  query="[expanded titles] — experienced in [key functions]. Based in [location].",
+  limit=25,
+  insights=false,
+  profile_scoring=true,
+  custom_filters={"companies": ["Target1", "Target2", ...]}
+)
+```
+
+**Why limit=25:** Pearch ranking has variance; candidates with non-tech current roles rank lower. Higher limit catches them.
+
+**Why custom_filters.companies:** This field searches across ALL career history, not just current role. It's the single most important parameter for exec sourcing — it finds strong candidates invisible to NL queries alone.
+
+### Step 3: Type B — Function Description (title-agnostic search)
+
+Search by describing the **work**, not the **title**. No job title in query — purely what the person has done.
+
+```
+search_people(
+  query="[description of work: built X, led Y, implemented Z] at high-growth companies in [location]. [experience years]+.",
+  limit=20,
+  insights=false,
+  profile_scoring=true
+)
+```
+
+This catches **non-standard titles** — people who do the right work under a different name.
+
+### Step 4: Deduplicate + Evaluate
+
+1. **Merge** results from all three queries. Remove duplicates by `docid`.
+2. **Score** each unique candidate using the 7-Dimensional Profile Scoring rubric (see below).
+3. **Check** against position-specific anti-patterns and red flags.
+4. **Rank** by composite score.
+5. **Select top 5-10** for the shortlist.
+
+### Step 5: Output
+
+Create two files in `Hiring/Sourcing/{Position Name}/`:
+
+**search-log.md** — query parameters, thread IDs, pool sizes, credits spent.
+
+**shortlist.md** — ranked candidates with:
+- Name, current title, company, location, LinkedIn
+- 7-dim scores table
+- Composite score
+- Why this candidate (2-3 sentences)
+- Risks (what to probe in interview)
+- Fit to company values
+
+## 7-Dimensional Profile Scoring
+
+Score each dimension 1-5. Trajectory and Scope expansion have highest weight.
+
+| # | Dimension | What to assess | Weight |
+|---|-----------|---------------|--------|
+| 1 | **Trajectory shape** | Promotions every 2-3 years (accelerating) vs plateau 5+ years | High |
+| 2 | **Scope expansion** | Team growth 5→25→50 = compounding leadership. 5→8→12 = ceiling | High |
+| 3 | **Company quality arc** | Strong→weak (red) vs weak→strong (green) | Medium |
+| 4 | **Tenure distribution** | Serial <18 months = never completed a full cycle | Medium |
+| 5 | **Team-following** | Did reports follow them to new companies? Strongest leadership signal | High |
+| 6 | **Crisis/turnaround** | Experience in downturns, pivots, restructurings | Medium |
+| 7 | **Board/advisory roles** | External validation, network quality | Low |
+
+**Important:** Years of experience is one of the worst predictors (validity 0.18). De-weight in favor of trajectory signals.
+
+## Credit Budget
+
+| Query | Estimated cost |
+|-------|---------------|
+| Type A (20 results, insights) | ~40 credits |
+| Type A+ (25 results, no insights) | ~25 credits |
+| Type B (20 results, no insights) | ~20 credits |
+| **Total per position** | **~85 credits** |
+
+Always report credits remaining after search.
+
+## Key Principles
+
+1. **Success Profile, not JD.** The search should be informed by what success looks like in 18 months, not a generic job description.
+2. **custom_filters.companies is the power tool.** It searches ALL career history. Always use it for Type A+.
+3. **Never rely on a single query.** Single queries have systematic blind spots — title mismatch, company type mismatch, or both.
+4. **Candidates who left tech are invisible to NL alone.** Type A+ with custom_filters.companies is the only reliable way to find them.
+5. **Culture-add, not culture-fit.** Look for complementary strengths, not clones of current team.
+6. **No contact data by default.** Don't enable reveal_emails/phones unless explicitly asked. Respect privacy, save credits.
+
+## Position-Specific Context
+
+If the vault contains `Hiring/hiring-criteria.md`, read it for:
+- Company values (evaluate culture alignment)
+- Leadership principles (if available)
+- Red flags and green signals specific to this org
+
+If the position file contains a `## Search Strategy Notes` section, use those hints for target companies and regional preferences.


### PR DESCRIPTION
## Summary

- Add `custom_filters` support to `search_people`, enabling structured filtering across **all experience history** (not just current role)
- Add missing parameters: `custom_filters_mode`, `strict_filters`, `docid_blacklist`, `high_freshness`, `filter_out_no_emails/phones`
- Add missing parameters to `search_company_leads`: `filter_out_no_emails/phones`, `high_freshness`, `select_top_leads`

## Motivation

When sourcing executive candidates, people who moved from tech to non-tech companies become invisible to NL queries alone (e.g., a "Head of L&D at Mollie" who is now "Director of Talent at ASICS"). The `custom_filters.companies` field searches across **all** experience history, not just the current role — making these candidates discoverable.

Tested with real executive search scenarios: `custom_filters.companies` found candidates that 5 different NL query variations missed.

## Test plan

- [x] Verified `custom_filters.companies` returns results matching historical experience
- [x] Verified backward compatibility — all existing parameters work unchanged
- [x] Verified `custom_filters_mode: "exact"` vs `"smart"` behavior
- [x] Tested with stdio transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)